### PR TITLE
Update gh-action.yml

### DIFF
--- a/.github/workflows/gh-action.yml
+++ b/.github/workflows/gh-action.yml
@@ -27,14 +27,14 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v2
-      - name: Setup Python 3.11.3
+      - name: Setup Python 3.11.4
         uses: actions/setup-python@v1
         with: 
-          python-version: 3.11.3
+          python-version: 3.11.4
       - name: Install python deps
         run: |
           python -m pip install --upgrade pip
-          pip install pyraider==1.0.11 
+          pip install pyraider==1.0.20
       - name: Get working directory
         run: echo $(PWD)
       - name: Scan packages
@@ -51,10 +51,10 @@ jobs:
     runs-on: ubuntu-latest
     steps: 
       - uses: actions/checkout@v2
-      - name: Setup Python 3.11.3
+      - name: Setup Python 3.11.4
         uses: actions/setup-python@v1
         with: 
-          python-version: 3.11.3
+          python-version: 3.11.4
       - name: Install python deps
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
This is fixed please accept the pull request.
Run actions/setup-python@v1
  with:
    python-version: 3.11.3
    architecture: x64
Error: Version 3.11.3 with arch x64 not found
Available versions:

3.10.12 (x64)
3.11.4 (x64)
3.7.17 (x64)
3.8.17 (x64)
3.9.17 (x64)